### PR TITLE
Added commas where commas were needed

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -24,9 +24,7 @@ $(function () {
             x: -20
         },
         xAxis: {
-
-            categories:   {{ years | tojson }}             
-            
+            categories:   {{ years | tojson }}
         },
         yAxis: [{
             title: {
@@ -47,7 +45,7 @@ $(function () {
                 color: Highcharts.getOptions().colors[2]
             }]
 
-        }]
+        }],
         tooltip: {
             valueSuffix: ' {{metric_units}}'
         },
@@ -61,7 +59,7 @@ $(function () {
             name: '{{nation}}',
             data: {{ argument | tojson }}
         },{
-            name: 'Population'
+            name: 'Population',
             data: {{ population | tojson}}
         }]
     });
@@ -110,7 +108,7 @@ $(function () {
             </tr>
         </thead>
         <tbody>
-     
+
             {% for year in years %}
               <tr>
               <td>{{ years[loop.index0] }}</td>


### PR DESCRIPTION
So this ended up being an error in the JSON dictionary that you tried to pass in...you were missing a couple of commas. It's possible to diagnose this problem by opening the Debug Console in Firefox (I don't know the exact menu item/keyboard shortcut, but just google for how to open it in Firefox)...the console shows any program-breaking errors on the JavaScript side (but not Python)...here's what it looks like in Google Chrome:

![image](https://cloud.githubusercontent.com/assets/121520/15733717/87065a7a-283d-11e6-9e8d-6d15aecd7858.png)

They key part is in the right side, which shows the file that contains the erroneous code (in this case, the URL route) and more importantly, **the line number**: `51`

```
results?country=France&metric=electricity&units=per+capita:51 
```

Depending on the type of JS error you have, this debug message can be helpful. Other kinds of syntax errors may not result in an exact pinpointing of the line.
